### PR TITLE
Print nice error message when larscrontab does not exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,13 @@ struct Cronproc<'a> {
 
 fn main() {
     let path = env::home_dir().unwrap().to_str().unwrap().to_owned() + "/.larscrontab";
-    let f = File::open(path).expect("~/.larscrontab file is missing");
+    let f = match File::open(&path) {
+        Ok(fd) => fd,
+        Err(e) => {
+            eprintln!("Could not find {}. Please create it first!", &path);
+            ::std::process::exit(1);
+        }
+    };
     let f = BufReader::new(f);
     let mut cron_vec: Vec<Cronproc> = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
     let path = env::home_dir().unwrap().to_str().unwrap().to_owned() + "/.larscrontab";
     let f = match File::open(&path) {
         Ok(fd) => fd,
-        Err(e) => {
+        Err(_e) => {
             eprintln!("Could not find {}. Please create it first!", &path);
             ::std::process::exit(1);
         }


### PR DESCRIPTION
This PR adds a somewhat more human readable message when we can't find the larscrontab file.

This improves the experience upon first time use.